### PR TITLE
Fix Lint Failure

### DIFF
--- a/examples/init.pp
+++ b/examples/init.pp
@@ -2,7 +2,7 @@
   $pkg = 'notepadplusplus'
 
   package { $pkg:
-    ensure          => 'latest',
-    provider        => 'chocolatey',
+    ensure   => 'latest',
+    provider => 'chocolatey',
   }
 #}


### PR DESCRIPTION
The linter was not liking the hash rocket alignment on the examples
file.
